### PR TITLE
Align screen blur with dynamic island

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -14,7 +14,7 @@ body::before {
   top: 0;
   left: 0;
   right: 0;
-  height: 80px;
+  height: calc(80px + env(safe-area-inset-top, 0));
   backdrop-filter: blur(24px);
   -webkit-backdrop-filter: blur(24px);
   z-index: 1000;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,11 @@ import BlurEntryAnimation from './components/BlurEntryAnimation';
 export const metadata: Metadata = {
   title: "Connor White",
   description: "Work from the personal studio of software designer and engineer, Connor White.",
+  viewport: {
+    width: "device-width",
+    initialScale: 1,
+    viewportFit: "cover",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Fixes progressive blur positioning on iOS devices with Dynamic Island.

The blur was incorrectly positioned below the Dynamic Island because the previous CSS `top: 0` and fixed height didn't account for iOS safe area insets. Adding `viewportFit: "cover"` allows content to extend into the safe area, and `calc(80px + env(safe-area-inset-top, 0))` dynamically adjusts the blur height to cover the Dynamic Island.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb637b1d-1372-4934-a5eb-c4d9bd7a1e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb637b1d-1372-4934-a5eb-c4d9bd7a1e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts the top blur to include the iOS safe-area inset and sets viewport metadata for full-bleed rendering.
> 
> - **Styling**:
>   - Update `body::before` height in `app/globals.css` to `calc(80px + env(safe-area-inset-top, 0))` to include the iOS safe-area inset.
> - **Metadata**:
>   - Add `viewport` settings in `app/layout.tsx` (`width=device-width`, `initialScale=1`, `viewportFit=cover`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1f02e0cb2ea85540c76ebe062deb46c9a3d3431. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->